### PR TITLE
Adjustment to BITCOINRPC_METHOD_SIGNRAWTRANSACTION

### DIFF
--- a/src/bitcoinrpc_method.c
+++ b/src/bitcoinrpc_method.c
@@ -93,7 +93,7 @@ const struct BITCOINRPC_METHOD_struct_
   { BITCOINRPC_METHOD_DECODESCRIPT, "decodescript" },
   { BITCOINRPC_METHOD_GETRAWTRANSACTION, "getrawtransaction" },
   { BITCOINRPC_METHOD_SENDRAWTRANSACTION, "sendrawtransaction" },
-  { BITCOINRPC_METHOD_SIGNRAWTRANSACTION, "signrawtransaction" },
+  { BITCOINRPC_METHOD_SIGNRAWTRANSACTION, "signrawtransactionwithwallet" },
 
   /* Utility RPCs */
   { BITCOINRPC_METHOD_CREATEMULTISIG, "createmultisig" },


### PR DESCRIPTION
the "signrawtransaction" was deprecated in 0.17, and so signing now segfaults(!). This updates to the new command "signrawtransactionwithwallet".