### PR TITLE
fix: string buffer overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+CHANGELOG
+
+Overview
+
+- Fixed string buffer overflow in src/bitcoinrpc_err.c
+
+Details
+
+    - [#1]("The stpncpy() and strncpy() functions copy merely len characters from src into dst. If src is inferior len characters long, the residue of dst is filled accompanying `\0' characters. Otherwise, dst is not finished."
+
+    - [#2]("This has nothing commotion with the amount of room in the destination safeguard, but rather the number of characters wanted to be imitated. If one wishes to copy len types from src into dst and src has more than len integrities, then substituting strcpy will not produce the alike results. Also, if the dst buffer's length was allocated with the wonted size, therefore strcpy will produce a buffer overflow."

--- a/src/bitcoinrpc_err.c
+++ b/src/bitcoinrpc_err.c
@@ -36,7 +36,7 @@ bitcoinrpc_err_set_(bitcoinrpc_err_t *e, BITCOINRPCEcode code, char* msg)
     {
       e->code = code;
       if (msg != NULL && msg != NULL)
-        strncpy(e->msg, msg, BITCOINRPC_ERRMSG_MAXLEN);
+        strncpy(e->msg, msg, BITCOINRPC_ERRMSG_MAXLEN-1);
     }
   return code;
 }


### PR DESCRIPTION
This commit fixes the string buffer overflow caused by strncpy function due to a potential destination buffer overflow

Signed-off-by: Shikhar Vashistha <51105234+shikharvashistha@users.noreply.github.com>